### PR TITLE
Fix import path for bitcask

### DIFF
--- a/golkeyval/bitcask.go
+++ b/golkeyval/bitcask.go
@@ -4,7 +4,7 @@ import (
 	"fmt"
 	"os"
 
-	bitcask "github.com/prologic/bitcask"
+	bitcask "git.mills.io/prologic/bitcask"
 
 	golerror "github.com/abhishekkr/gol/golerror"
 )


### PR DESCRIPTION
Project has moved to [git.mills.io/prologic/bitcask](https://git.mills.io/prologic/bitcask).

For details on why see: https://github.com/prologic

Thank you! 🙇